### PR TITLE
Add connection string options

### DIFF
--- a/MssqlMcp/Node/README.md
+++ b/MssqlMcp/Node/README.md
@@ -141,7 +141,9 @@ This server leverages the Model Context Protocol (MCP), a versatile framework th
 - **SERVER_NAME**: Your MSSQL Database server name (e.g., `my-server.database.windows.net`)
 - **DATABASE_NAME**: Your database name
 - **READONLY**: Set to `"true"` to restrict to read-only operations, `"false"` for full access
-- **Path**: Update the path in `args` to point to your actual project location
+- **Path**: Update the path in `args` to point to your actual project location.
+- **CONNECTION_TIMEOUT**: (Optional) Connection timeout in seconds. Defaults to `30` if not set.
+- **TRUST_SERVER_CERTIFICATE**: (Optional) Set to `"true"` to trust self-signed server certificates (useful for development or when connecting to servers with self-signed certs). Defaults to `"false"`.
 
 ## Sample Configurations
 

--- a/MssqlMcp/Node/src/index.ts
+++ b/MssqlMcp/Node/src/index.ts
@@ -36,12 +36,17 @@ export async function createSqlConfig(): Promise<{ config: sql.config, token: st
     // disableAutomaticAuthentication : true
   });
   const accessToken = await credential.getToken('https://database.windows.net/.default');
+
+  const trustServerCertificate = process.env.TRUST_SERVER_CERTIFICATE?.toLowerCase() === 'true';
+  const connectionTimeout = process.env.CONNECTION_TIMEOUT ? parseInt(process.env.CONNECTION_TIMEOUT, 10) : 30;
+
   return {
     config: {
       server: process.env.SERVER_NAME!,
       database: process.env.DATABASE_NAME!,
       options: {
         encrypt: true,
+        trustServerCertificate
       },
       authentication: {
         type: 'azure-active-directory-access-token',
@@ -49,6 +54,7 @@ export async function createSqlConfig(): Promise<{ config: sql.config, token: st
           token: accessToken?.token!,
         },
       },
+      connectionTimeout: connectionTimeout * 1000, // convert seconds to milliseconds
     },
     token: accessToken?.token!,
     expiresOn: accessToken?.expiresOnTimestamp ? new Date(accessToken.expiresOnTimestamp) : new Date(Date.now() + 30 * 60 * 1000)


### PR DESCRIPTION
Allows users the ability to optionally configure the following settings in the connection string
- Trust Server Certificate
- Connection Timeout